### PR TITLE
[FIX] Send 404 if not found

### DIFF
--- a/src/enums/StatusCodes.ts
+++ b/src/enums/StatusCodes.ts
@@ -1,3 +1,4 @@
 export enum STATUS_CODES {
-    GONE = 410
+    GONE = 410,
+    NOT_FOUND = 404
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,6 +41,8 @@ function createRoutesForEntityBoundToContract(app, entity: ENTITY) {
         const existingData = storage.get(entity, contractAddress);
 
         if (!existingData) {
+            res.status(STATUS_CODES.NOT_FOUND).end();
+
             return;
         }
 


### PR DESCRIPTION
If data about an entity is not found in the database, send a 404 response instead of keeping silent.