### PR TITLE
Allow getting all values for OriginContractLookupMarketLookupMapping

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+sudo: required
+dist: trusty
+language: node_js
+node_js:
+  - '10.0.0'
+
+install:
+  - npm install
+ 
+script:
+  - npm run build
+  - npm test

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "shx rm -rf dist/js && tsc",
     "lint": "tslint --fix  'src/**/*{.ts,.tsx}'",
     "prettier": "prettier --write --config-precedence file-override './src/**/*'",
-    "prepare": "npm run build"
+    "prepare": "npm run build",
+    "test": "rm -rf db.json && npm run build && mocha dist/js/test/ --timeout 60000"
   },
   "repository": {
     "type": "git",
@@ -28,7 +29,12 @@
     "js-beautify": "1.10.0"
   },
   "devDependencies": {
+    "@types/chai": "4.1.4",
+    "@types/mocha": "2.2.48",
+    "axios": "^0.19.0",
+    "chai": "4.2.0",
     "lint-staged": "8.1.7",
+    "mocha": "6.2.0",
     "prettier": "1.17.1",
     "shx": "0.3.2",
     "tslint": "5.16.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "devDependencies": {
     "@types/chai": "4.1.4",
     "@types/mocha": "2.2.48",
-    "axios": "^0.19.0",
+    "axios": "0.19.0",
     "chai": "4.2.0",
     "lint-staged": "8.1.7",
     "mocha": "6.2.0",

--- a/src/api.ts
+++ b/src/api.ts
@@ -10,7 +10,7 @@ export async function startAPI() {
     const app = express();
 
     app.use(cors());
-    
+
     const storage = new CustomStorage(
         [
             ENTITY.TRADABLE_ENTITY,
@@ -20,80 +20,78 @@ export async function startAPI() {
             ENTITY.DEMAND,
             ENTITY.SUPPLY,
             ENTITY.AGREEMENT,
-            ENTITY.MATCHER,
-            ENTITY.ORIGIN_LOOKUP_TO_MARKET_LOOKUP_MAPPING,
-            ENTITY.ORIGIN_LOOKUP_TO_ASSET_LOOKUP_MAPPING
+            ENTITY.MATCHER
         ],
         new FileAdapter('db.json')
     );
-    
+
     app.use(bodyParser.json());
-    
+
     app.use(cors());
-    
+
     app.options('*', cors());
-    
+
     function createRoutesForEntityBoundToContract(app, entity: ENTITY) {
         app.get(`/${entity}/:contractAddress/:id`, (req, res) => {
             const contractAddress = req.params.contractAddress.toLowerCase();
-    
+
             console.log(`GET - ${entity} ${req.params.id} (contract ${contractAddress})`);
-    
+
             const existingData = storage.get(entity, contractAddress);
-    
+
             if (!existingData) {
                 res.status(STATUS_CODES.NOT_FOUND).end();
-    
+
                 return;
             }
-    
+
             if (existingData in STATUS_CODES) {
                 res.status(STATUS_CODES[existingData]).end();
-    
+
                 return;
             }
-    
+
             res.send(existingData[req.params.id]);
         });
-    
+
         app.put(`/${entity}/:contractAddress/:id`, (req, res) => {
             const contractAddress = req.params.contractAddress.toLowerCase();
             console.log(`PUT - ${entity} ${req.params.id} (contract ${contractAddress})`);
-    
+
             let existingData = storage.get(entity, contractAddress);
-    
+
             if (!existingData) {
                 existingData = {};
             }
-    
+
             storage.set(entity, contractAddress, Object.assign(existingData, {
                 [req.params.id]: req.body
             }));
-    
+
             res.send('success');
         });
-    
+
         app.delete(`/${entity}/:contractAddress/:id`, (req, res) => {
             const contractAddress = req.params.contractAddress.toLowerCase();
             console.log(`DELETE - ${entity} ${req.params.id}`);
-    
+
             let existingData = storage.get(entity, contractAddress);
-    
+
             if (!existingData) {
                 existingData = {};
             }
-    
+
             storage.set(entity, contractAddress, Object.assign(existingData, {
                 [req.params.id]: STATUS_CODES.GONE
             }));
-    
+
             res.send('success');
         });
     }
     createRoutesForEntityBoundToContract(app, ENTITY.TRADABLE_ENTITY);
     createRoutesForEntityBoundToContract(app, ENTITY.PRODUCING_ASSET);
     createRoutesForEntityBoundToContract(app, ENTITY.DEMAND);
-    
+
     /**
      * Producing Asset
      */
@@ -101,15 +99,15 @@ export async function startAPI() {
         console.log(`GET - ProducingAssetNotBound ${req.params.id}`);
         res.send(storage.get(ENTITY.PRODUCING_ASSET_NOT_BOUND, req.params.id));
     });
-    
+
     app.put('/ProducingAsset/:id', (req, res) => {
         console.log(`PUT - ProducingAssetNotBound ${req.params.id}`);
-    
+
         storage.set(ENTITY.PRODUCING_ASSET_NOT_BOUND, req.params.id, req.body);
-    
+
         res.send('success');
     });
-    
+
     /**
      * Consuming Asset
      */
@@ -117,31 +115,31 @@ export async function startAPI() {
         console.log(`GET - ConsumingAsset ${req.params.id}`);
         res.send(storage.get(ENTITY.CONSUMING_ASSET, req.params.id));
     });
-    
+
     app.put('/ConsumingAsset/:id', (req, res) => {
         console.log(`PUT - ConsumingAsset ${req.params.id}`);
-    
+
         storage.set(ENTITY.CONSUMING_ASSET, req.params.id, req.body);
-    
+
         res.send('success');
     });
-    
+
     /**
      * Supply
      */
     app.get('/Supply/:id', (req, res) => {
         console.log(`GET - Supply ${req.params.id}`);
-    
+
         res.send(storage.get(ENTITY.SUPPLY, req.params.id));
     });
-    
+
     app.put('/Supply/:id', (req, res) => {
         console.log(`PUT - Supply ${req.params.id}`);
         storage.set(ENTITY.SUPPLY, req.params.id, req.body);
-    
+
         res.send('success');
     });
-    
+
     /**
      * Agreements
      */
@@ -149,15 +147,15 @@ export async function startAPI() {
         console.log(`GET - Agreement ${req.params.id}`);
         res.send(storage.get(ENTITY.AGREEMENT, req.params.id));
     });
-    
+
     app.put('/Agreement/:id', (req, res) => {
         console.log(`PUT - Agreement ${req.params.id}`);
-    
+
         storage.set(ENTITY.AGREEMENT, req.params.id, req.body);
-    
+
         res.send('success');
     });
-    
+
     /**
      * Matcher
      */
@@ -165,18 +163,23 @@ export async function startAPI() {
         console.log(`GET - Matcher ${req.params.id}`);
         res.send(storage.get(ENTITY.MATCHER, req.params.id));
     });
-    
+
     app.put('/Matcher/:id', (req, res) => {
         console.log(`PUT - Matcher ${req.params.id}`);
         storage.set(ENTITY.MATCHER, req.params.id, req.body);
-    
+
         res.send('success');
     });
-    
-    app.get('/OriginContractLookupMarketLookupMapping/:id', (req, res) => {
+
+    app.get('/OriginContractLookupMarketLookupMapping/:id?', (req, res) => {
         console.log(`GET - OriginContractLookupMarketLookupMapping ${req.params.id}`);
-    
-        res.send(storage.get(ENTITY.ORIGIN_LOOKUP_TO_MARKET_LOOKUP_MAPPING, req.params.id && req.params.id.toLowerCase()));
+
+        res.send(
+            storage.get(
+                ENTITY.ORIGIN_LOOKUP_TO_MARKET_LOOKUP_MAPPING,
+                req.params.id !== undefined ? req.params.id.toLowerCase() : null
+            )
+        );
     });
     
     app.put('/OriginContractLookupMarketLookupMapping/:id', (req, res) => {

--- a/src/api.ts
+++ b/src/api.ts
@@ -181,26 +181,26 @@ export async function startAPI() {
             )
         );
     });
-    
+
     app.put('/OriginContractLookupMarketLookupMapping/:id', (req, res) => {
         console.log(`PUT - OriginContractLookupMarketLookupMapping ${req.params.id}`);
-    
+
         storage.set(ENTITY.ORIGIN_LOOKUP_TO_MARKET_LOOKUP_MAPPING, req.params.id && req.params.id.toLowerCase(), req.body);
-    
+
         res.send('success');
     });
-    
+
     app.get('/OriginContractLookupAssetLookupMapping/:id', (req, res) => {
         console.log(`GET - OriginContractLookupAssetLookupMapping ${req.params.id}`);
-    
+
         res.send(storage.get(ENTITY.ORIGIN_LOOKUP_TO_ASSET_LOOKUP_MAPPING, req.params.id && req.params.id.toLowerCase()));
     });
-    
+
     app.put('/OriginContractLookupAssetLookupMapping/:id', (req, res) => {
         console.log(`PUT - OriginContractLookupAssetLookupMapping ${req.params.id}`);
-    
+
         storage.set(ENTITY.ORIGIN_LOOKUP_TO_ASSET_LOOKUP_MAPPING, req.params.id && req.params.id.toLowerCase(), req.body);
-    
+
         res.send('success');
     });
 

--- a/src/storage/storage.ts
+++ b/src/storage/storage.ts
@@ -25,9 +25,13 @@ export class CustomStorage {
         });
     }
 
-    get(type: ENTITY, key: string) {
+    get(type: ENTITY, key?: string) {
         if (arguments.length > 2) {
             throw new Error('Storage::get()::Too many arguments passed');
+        }
+
+        if (key === undefined || key === null) {
+            return this._adapter.get(type);
         }
 
         return this._adapter.get(type)[key];

--- a/test/TestStorage.ts
+++ b/test/TestStorage.ts
@@ -1,0 +1,35 @@
+import axios from 'axios';
+import 'mocha';
+import { assert } from 'chai';
+
+import { startAPI } from '../src/api';
+
+describe('Storage tests', async () => {
+    before(async () => {
+        await startAPI();
+    });
+
+    it('init Origin contract', async () => {
+        const result = await axios.put(
+            'http://localhost:3030/OriginContractLookupMarketLookupMapping/0xb4ec89404c4a24f4c80d157ba9ad803cbc4db614',
+            {
+                "marketContractLookup": "0x665b25e0edc2d9b5dee75c5f652f92f5b58be12b"
+            }
+        );
+
+        console.log(result);
+        assert.equal(result.status, 200);
+    });
+
+    it('gets all Origin contracts', async () => {
+        const result = await axios.get('http://localhost:3030/OriginContractLookupMarketLookupMapping');
+
+        const expectedResult = {
+            '0xb4ec89404c4a24f4c80d157ba9ad803cbc4db614': {
+                marketContractLookup: '0x665b25e0edc2d9b5dee75c5f652f92f5b58be12b'
+            }
+        };
+
+        assert.deepEqual(result.data, expectedResult);
+    });
+});

--- a/test/TestStorage.ts
+++ b/test/TestStorage.ts
@@ -11,6 +11,10 @@ describe('Storage tests', async () => {
         apiServer = await startAPI();
     });
 
+    after(() => {
+        apiServer.close();
+    });
+
     it('init Origin contract', async () => {
         const result = await axios.put(
             'http://localhost:3030/OriginContractLookupMarketLookupMapping/0xb4ec89404c4a24f4c80d157ba9ad803cbc4db614',
@@ -32,6 +36,5 @@ describe('Storage tests', async () => {
         };
 
         assert.deepEqual(result.data, expectedResult);
-        apiServer.close();
     });
 });

--- a/test/TestStorage.ts
+++ b/test/TestStorage.ts
@@ -5,19 +5,20 @@ import { assert } from 'chai';
 import { startAPI } from '../src/api';
 
 describe('Storage tests', async () => {
+    let apiServer;
+
     before(async () => {
-        await startAPI();
+        apiServer = await startAPI();
     });
 
     it('init Origin contract', async () => {
         const result = await axios.put(
             'http://localhost:3030/OriginContractLookupMarketLookupMapping/0xb4ec89404c4a24f4c80d157ba9ad803cbc4db614',
             {
-                "marketContractLookup": "0x665b25e0edc2d9b5dee75c5f652f92f5b58be12b"
+                marketContractLookup: '0x665b25e0edc2d9b5dee75c5f652f92f5b58be12b'
             }
         );
 
-        console.log(result);
         assert.equal(result.status, 200);
     });
 
@@ -31,5 +32,6 @@ describe('Storage tests', async () => {
         };
 
         assert.deepEqual(result.data, expectedResult);
+        apiServer.close();
     });
 });

--- a/test/TestStorage.ts
+++ b/test/TestStorage.ts
@@ -15,26 +15,21 @@ describe('Storage tests', async () => {
         apiServer.close();
     });
 
-    it('init Origin contract', async () => {
-        const result = await axios.put(
+    it('gets all Origin contracts', async () => {
+        const putResult = await axios.put(
             'http://localhost:3030/OriginContractLookupMarketLookupMapping/0xb4ec89404c4a24f4c80d157ba9ad803cbc4db614',
             {
                 marketContractLookup: '0x665b25e0edc2d9b5dee75c5f652f92f5b58be12b'
             }
         );
+        assert.equal(putResult.status, 200);
 
-        assert.equal(result.status, 200);
-    });
-
-    it('gets all Origin contracts', async () => {
-        const result = await axios.get('http://localhost:3030/OriginContractLookupMarketLookupMapping');
-
+        const getResult = await axios.get('http://localhost:3030/OriginContractLookupMarketLookupMapping');
         const expectedResult = {
             '0xb4ec89404c4a24f4c80d157ba9ad803cbc4db614': {
                 marketContractLookup: '0x665b25e0edc2d9b5dee75c5f652f92f5b58be12b'
             }
         };
-
-        assert.deepEqual(result.data, expectedResult);
+        assert.deepEqual(getResult.data, expectedResult);
     });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,6 +17,7 @@
         ]
     },
     "include": [
+        "./test/*",
         "./src/**/*",
         "./env.json"
     ]


### PR DESCRIPTION
This enables us to get all initialized Origin contracts from the backend.

Includes: 
- Tests
- Travis configuration